### PR TITLE
update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,25 @@ COPY ./model .
 RUN pip3 install -r requirements.txt
 RUN python3 build_model.py
 
-
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 cartesi/python:3.10-slim-jammy
 
-LABEL io.sunodo.sdk_version=0.2.0
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.14.1
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
+LABEL io.sunodo.sdk_version=0.4.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
+set -e
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
-rm -rf /var/lib/apt/lists/*
+apt-get install -y --no-install-recommends \
+  busybox-static=1:1.30.1-7ubuntu3
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+useradd --create-home --user-group dapp
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"
@@ -28,6 +33,7 @@ WORKDIR /opt/cartesi/dapp
 COPY ./requirements.txt .
 
 RUN <<EOF
+set -e
 pip install -r requirements.txt --no-cache
 find /usr/local/lib -type d -name __pycache__ -exec rm -r {} +
 EOF


### PR DESCRIPTION
## Brief
- `sunodo build` fails when you try use the latest version due to unsupported sdk version

## Activities
- updated the Dockerfile to make sure it works with the latest version of sunodo

## Evidence
<img width="1238" alt="Screenshot 2024-04-24 at 5 45 42 PM" src="https://github.com/Mugen-Builders/m2cgen/assets/65580797/3462afbd-312c-400b-8b54-857f52e6eef5">
<img width="1448" alt="Screenshot 2024-04-24 at 5 50 46 PM" src="https://github.com/Mugen-Builders/m2cgen/assets/65580797/6494b3c2-79df-43b2-a7c8-67cb6388d8fd">
